### PR TITLE
Dropped allowBackup from lib's manifest

### DIFF
--- a/permissions-manager/src/main/AndroidManifest.xml
+++ b/permissions-manager/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
           xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
         <activity


### PR DESCRIPTION
This patch prevents app from build error even though the app has `allowBackup="false"` in it's manifest.